### PR TITLE
Fix Shuffle and TrimTo logic

### DIFF
--- a/NadekoBot/Classes/Extensions.cs
+++ b/NadekoBot/Classes/Extensions.cs
@@ -43,10 +43,10 @@ namespace NadekoBot.Extensions
                 throw new ArgumentOutOfRangeException(nameof(num), "TrimTo argument cannot be less than 0");
             if (num == 0)
                 return string.Empty;
-            if (num <= 3)
-                return string.Join("", str.Select(c => '.'));
-            if (str.Length < num)
+            if (str.Length <= num)
                 return str;
+            if (num <= 3)
+                return new string('.', num);
             return string.Join("", str.Take(num - 3)) + (hideDots ? "" : "...");
         }
         /// <summary>

--- a/NadekoBot/Modules/Gambling/Helpers/Cards.cs
+++ b/NadekoBot/Modules/Gambling/Helpers/Cards.cs
@@ -144,7 +144,7 @@ namespace NadekoBot.Modules.Gambling.Helpers
         {
             if (cardPool.Count <= 1) return;
             var orderedPool = cardPool.OrderBy(x => r.Next());
-            cardPool = cardPool as List<Card> ?? orderedPool.ToList();
+            cardPool = orderedPool.ToList();
         }
         public override string ToString() => string.Join("", cardPool.Select(c => c.ToString())) + Environment.NewLine;
 


### PR DESCRIPTION
## Summary
- fix card deck shuffle not randomizing
- fix TrimTo to respect limit and return the correct ellipsis

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847497ad43c83208552f4b2a64323e6